### PR TITLE
Add "Architectures:" line to Release file

### DIFF
--- a/ansible/roles/jenkins/files/scripts/update-apt-release.sh
+++ b/ansible/roles/jenkins/files/scripts/update-apt-release.sh
@@ -17,7 +17,7 @@ test -f "$RELEASE"
 
 rm -f "$DISTDIR/Release" "$DISTDIR/Release.gpg"
 
-apt-ftparchive -o "APT::FTPArchive::Release::Codename=$DIST" release "$DISTDIR" > "$RELEASE"
+apt-ftparchive -o "APT::FTPArchive::Release::Architectures"="amd64 i386" -o "APT::FTPArchive::Release::Codename=$DIST" release "$DISTDIR" > "$RELEASE"
 mv "$RELEASE" "$DISTDIR/Release"
 chmod 0644 "$DISTDIR/Release"
 gpg --detach-sign --armor --batch --default-key ci@collectd.org --output "$DISTDIR/Release.gpg" "$DISTDIR/Release"


### PR DESCRIPTION
to help some APT "clients" like Aptly to work correctly