### PR TITLE
Install the xfsprogs headers

### DIFF
--- a/packer/scripts/el5.sh
+++ b/packer/scripts/el5.sh
@@ -13,7 +13,7 @@ yum -y update
 
 yum -y install autoconf automake bison cpp curl flex gcc gdb git glibc-devel libgcrypt-devel libtool libtool-ltdl-devel m4 make nc pkgconfig redhat-rpm-config strace tar valgrind
 
-yum -y install OpenIPMI-devel curl-devel ganglia-devel gtk2-devel iptables-devel java-1.7.0-openjdk-devel java-devel jpackage-utils libcap-devel libdbi-devel libesmtp-devel libmemcached-devel libmnl-devel libnotify-devel liboping-devel libpcap-devel librabbitmq-devel libvirt-devel libxml2-devel lm_sensors-devel mysql-devel net-snmp-devel nut-devel openldap-devel postgresql-devel protobuf-c-devel python26-devel rrdtool-devel varnish-libs-devel openldap-devel
+yum -y install OpenIPMI-devel curl-devel ganglia-devel gtk2-devel iptables-devel java-1.7.0-openjdk-devel java-devel jpackage-utils libcap-devel libdbi-devel libesmtp-devel libmemcached-devel libmnl-devel libnotify-devel liboping-devel libpcap-devel librabbitmq-devel libvirt-devel libxml2-devel lm_sensors-devel mysql-devel net-snmp-devel nut-devel openldap-devel postgresql-devel protobuf-c-devel python26-devel rrdtool-devel varnish-libs-devel openldap-devel xfsprogs-devel
 
 yum -y clean all
 

--- a/packer/scripts/el6.sh
+++ b/packer/scripts/el6.sh
@@ -13,7 +13,7 @@ yum -y update
 
 yum -y install autoconf automake bison clang cpp curl flex gcc gdb git glibc-devel libgcrypt-devel libtool libtool-ltdl-devel m4 make nc pkgconfig redhat-rpm-config strace tar valgrind
 
-yum -y install OpenIPMI-devel ganglia-devel iproute-devel iptables-devel java-1.7.0-openjdk-devel java-devel jpackage-utils libatasmart-devel libcap-devel libcurl-devel libdbi-devel libesmtp-devel libmemcached-devel libmnl-devel libmodbus-devel libnotify-devel liboping-devel libpcap-devel librabbitmq-devel libstatgrab-devel libvirt-devel libxml2-devel lm_sensors-devel lvm2-devel mysql-devel net-snmp-devel nut-devel openldap-devel perl-ExtUtils-Embed postgresql-devel protobuf-c-devel python-devel rrdtool-devel varnish-libs-devel yajl-devel hiredis-devel libudev-devel
+yum -y install OpenIPMI-devel ganglia-devel iproute-devel iptables-devel java-1.7.0-openjdk-devel java-devel jpackage-utils libatasmart-devel libcap-devel libcurl-devel libdbi-devel libesmtp-devel libmemcached-devel libmnl-devel libmodbus-devel libnotify-devel liboping-devel libpcap-devel librabbitmq-devel libstatgrab-devel libvirt-devel libxml2-devel lm_sensors-devel lvm2-devel mysql-devel net-snmp-devel nut-devel openldap-devel perl-ExtUtils-Embed postgresql-devel protobuf-c-devel python-devel rrdtool-devel varnish-libs-devel yajl-devel hiredis-devel libudev-devel xfsprogs-devel
 
 yum -y clean all
 

--- a/packer/scripts/el7.sh
+++ b/packer/scripts/el7.sh
@@ -8,7 +8,7 @@ yum -y update
 
 yum -y install autoconf automake bison clang cpp curl flex gcc gdb git glibc-devel libgcrypt-devel libtool libtool-ltdl-devel m4 make nc pkgconfig redhat-rpm-config strace tar valgrind
 
-yum -y install OpenIPMI-devel ganglia-devel gtk2-devel gpsd-devel iproute-devel iptables-devel java-1.7.0-openjdk-devel java-devel jpackage-utils libatasmart-devel libcap-devel libcurl-devel libdbi-devel libesmtp-devel hiredis-devel libmemcached-devel libmnl-devel mosquitto-devel libnotify-devel openldap-devel libmodbus-devel liboping-devel libpcap-devel librabbitmq-devel libudev-devel libvirt-devel libxml2-devel lm_sensors-devel lvm2-devel mysql-devel net-snmp-devel nut-devel openldap-devel perl-ExtUtils-Embed postgresql-devel protobuf-c-devel python-devel rrdtool-devel varnish-libs-devel xmms-devel yajl-devel
+yum -y install OpenIPMI-devel ganglia-devel gtk2-devel gpsd-devel iproute-devel iptables-devel java-1.7.0-openjdk-devel java-devel jpackage-utils libatasmart-devel libcap-devel libcurl-devel libdbi-devel libesmtp-devel hiredis-devel libmemcached-devel libmnl-devel mosquitto-devel libnotify-devel openldap-devel libmodbus-devel liboping-devel libpcap-devel librabbitmq-devel libudev-devel libvirt-devel libxml2-devel lm_sensors-devel lvm2-devel mysql-devel net-snmp-devel nut-devel openldap-devel perl-ExtUtils-Embed postgresql-devel protobuf-c-devel python-devel rrdtool-devel varnish-libs-devel xmms-devel yajl-devel xfsprogs-devel
 
 yum -y clean all
 

--- a/packer/scripts/jessie.sh
+++ b/packer/scripts/jessie.sh
@@ -11,7 +11,7 @@ apt-get -y update
 apt-get -y upgrade
 
 apt-get -y install autoconf automake bison clang cpp dpkg-dev flex gcc gcc-4.8 gdb git libc6-dev libtool m4 make musl-dev musl-tools pkg-config strace valgrind
-apt-get -y install autotools-dev default-jdk iptables-dev javahelper libatasmart-dev libcap-dev libcurl4-gnutls-dev libdbi0-dev libesmtp-dev libganglia1-dev libgcrypt11-dev libglib2.0-dev libgps-dev libhiredis-dev libi2c-dev libldap2-dev libltdl-dev liblvm2-dev libmemcached-dev libmnl-dev libmodbus-dev libmosquitto-dev libmysqlclient-dev libnotify-dev libopenipmi-dev liboping-dev libow-dev libpcap-dev libperl-dev libpq-dev libprotobuf-c0-dev librabbitmq-dev librdkafka-dev librrd-dev libsensors4-dev libsigrok-dev libsnmp-dev libstatgrab-dev libtokyocabinet-dev libtokyotyrant-dev libudev-dev libupsclient-dev libvarnish-dev libvirt-dev libxml2-dev libyajl-dev linux-libc-dev perl protobuf-c-compiler python-dev
+apt-get -y install autotools-dev default-jdk iptables-dev javahelper libatasmart-dev libcap-dev libcurl4-gnutls-dev libdbi0-dev libesmtp-dev libganglia1-dev libgcrypt11-dev libglib2.0-dev libgps-dev libhiredis-dev libi2c-dev libldap2-dev libltdl-dev liblvm2-dev libmemcached-dev libmnl-dev libmodbus-dev libmosquitto-dev libmysqlclient-dev libnotify-dev libopenipmi-dev liboping-dev libow-dev libpcap-dev libperl-dev libpq-dev libprotobuf-c0-dev librabbitmq-dev librdkafka-dev librrd-dev libsensors4-dev libsigrok-dev libsnmp-dev libstatgrab-dev libtokyocabinet-dev libtokyotyrant-dev libudev-dev libupsclient-dev libvarnish-dev libvirt-dev libxml2-dev libyajl-dev linux-libc-dev perl protobuf-c-compiler python-dev xfslibs-dev
 
 apt-get -y clean
 

--- a/packer/scripts/precise.sh
+++ b/packer/scripts/precise.sh
@@ -10,7 +10,7 @@ apt-get -y update
 apt-get -y upgrade
 
 apt-get -y install autoconf automake bison clang cpp dpkg-dev flex gcc gcc-4.4 gcc-4.5 gdb git libc6-dev libtool m4 make pkg-config strace valgrind
-apt-get -y install autotools-dev default-jdk iproute-dev iptables-dev javahelper libatasmart-dev libcap-dev libcurl4-gnutls-dev libdbi0-dev libesmtp-dev libganglia1-dev libgcrypt11-dev libglib2.0-dev libgps-dev libhal-dev libhiredis-dev libi2c-dev libldap2-dev libltdl-dev liblvm2-dev libmemcached-dev libmnl-dev libmodbus-dev libmosquitto0-dev libmysqlclient-dev libnotify-dev libopenipmi-dev liboping-dev libow-dev libpcap-dev libperl-dev libpq-dev libprotobuf-c0-dev librabbitmq-dev librrd-dev libsensors4-dev libsnmp-dev libstatgrab-dev libtokyocabinet-dev libtokyotyrant-dev libudev-dev libupsclient1-dev libvarnish-dev libvirt-dev libxml2-dev libyajl-dev linux-libc-dev perl protobuf-c-compiler python-dev
+apt-get -y install autotools-dev default-jdk iproute-dev iptables-dev javahelper libatasmart-dev libcap-dev libcurl4-gnutls-dev libdbi0-dev libesmtp-dev libganglia1-dev libgcrypt11-dev libglib2.0-dev libgps-dev libhal-dev libhiredis-dev libi2c-dev libldap2-dev libltdl-dev liblvm2-dev libmemcached-dev libmnl-dev libmodbus-dev libmosquitto0-dev libmysqlclient-dev libnotify-dev libopenipmi-dev liboping-dev libow-dev libpcap-dev libperl-dev libpq-dev libprotobuf-c0-dev librabbitmq-dev librrd-dev libsensors4-dev libsnmp-dev libstatgrab-dev libtokyocabinet-dev libtokyotyrant-dev libudev-dev libupsclient1-dev libvarnish-dev libvirt-dev libxml2-dev libyajl-dev linux-libc-dev perl protobuf-c-compiler python-dev xfslibs-dev
 apt-get -y install openjdk-7-jre-headless
 
 apt-get -y clean

--- a/packer/scripts/trusty.sh
+++ b/packer/scripts/trusty.sh
@@ -10,7 +10,7 @@ apt-get -y update
 apt-get -y upgrade
 
 apt-get -y install autoconf automake bison clang cpp dpkg-dev flex gcc gcc-4.4 gcc-4.6 gcc-4.7 gcc-4.8 gdb git libc6-dev libtool m4 make pkg-config strace valgrind
-apt-get -y install autotools-dev default-jdk iptables-dev javahelper libatasmart-dev libcap-dev libcurl4-gnutls-dev libdbi0-dev libesmtp-dev libganglia1-dev libgcrypt11-dev libglib2.0-dev libgps-dev libhiredis-dev libi2c-dev libldap2-dev libltdl-dev liblvm2-dev libmemcached-dev libmnl-dev libmodbus-dev libmosquitto0-dev libmysqlclient-dev libnotify-dev libopenipmi-dev liboping-dev libow-dev libpcap-dev libperl-dev libpq-dev libprotobuf-c0-dev librabbitmq-dev librdkafka-dev librrd-dev libsensors4-dev libstatgrab-dev libsigrok-dev libsnmp-dev libtokyocabinet-dev libtokyotyrant-dev libudev-dev libupsclient-dev libvarnish-dev libvirt-dev libxml2-dev libyajl-dev linux-libc-dev perl protobuf-c-compiler python-dev
+apt-get -y install autotools-dev default-jdk iptables-dev javahelper libatasmart-dev libcap-dev libcurl4-gnutls-dev libdbi0-dev libesmtp-dev libganglia1-dev libgcrypt11-dev libglib2.0-dev libgps-dev libhiredis-dev libi2c-dev libldap2-dev libltdl-dev liblvm2-dev libmemcached-dev libmnl-dev libmodbus-dev libmosquitto0-dev libmysqlclient-dev libnotify-dev libopenipmi-dev liboping-dev libow-dev libpcap-dev libperl-dev libpq-dev libprotobuf-c0-dev librabbitmq-dev librdkafka-dev librrd-dev libsensors4-dev libstatgrab-dev libsigrok-dev libsnmp-dev libtokyocabinet-dev libtokyotyrant-dev libudev-dev libupsclient-dev libvarnish-dev libvirt-dev libxml2-dev libyajl-dev linux-libc-dev perl protobuf-c-compiler python-dev xfslibs-dev
 
 apt-get -y clean
 

--- a/packer/scripts/wheezy.sh
+++ b/packer/scripts/wheezy.sh
@@ -12,7 +12,7 @@ apt-get -y upgrade
 
 apt-get -y install autoconf automake bison clang cpp dpkg-dev flex gcc gcc-4.4 gcc-4.6 gdb git libc6-dev libtool m4 make pkg-config strace valgrind
 apt-get -y install autotools-dev default-jdk iproute-dev iptables-dev javahelper libatasmart-dev libcap-dev libcurl4-gnutls-dev libdbi0-dev libesmtp-dev libganglia1-dev libgcrypt11-dev libglib2.0-dev libgps-dev libhal-dev libhiredis-dev libi2c-dev libldap2-dev libltdl-dev liblvm2-dev libmemcached-dev libmnl-dev libmodbus-dev libmosquitto0-dev libmysqlclient-dev libnotify-dev libopenipmi-dev liboping-dev libow-dev libpcap-dev libperl-dev libpq-dev libprotobuf-c0-dev librabbitmq-dev librrd-dev libsensors4-dev libsnmp-dev libstatgrab-dev libtokyocabinet-dev libtokyotyrant-dev libudev-dev libupsclient1-dev libvarnish-dev libvirt-dev libxml2-dev libyajl-dev linux-libc-dev perl protobuf-c-compiler python-dev
-apt-get -y install openjdk-7-jre-headless
+apt-get -y install openjdk-7-jre-headless xfslibs-dev
 
 apt-get -y clean
 


### PR DESCRIPTION
utils_mount.c can optionally use XFS.
To detect breakage like
https://github.com/collectd/collectd/commit/865a6c83250e3d4381596a0d937df31d563f97c6,
install the xfsprogs headers.